### PR TITLE
Upgrade OMRS version from 2.1.1 to 2.4.2 in Pacs Query Module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
 	</distributionManagement>
 
     <properties>
-        <openmrsPlatformVersion>2.1.1</openmrsPlatformVersion>
-		<openmrsWebServicesVersion>2.17</openmrsWebServicesVersion>
+        <openmrsPlatformVersion>2.4.2</openmrsPlatformVersion>
+		<openmrsWebServicesVersion>2.29.0</openmrsWebServicesVersion>
     </properties>
 
 	<build>


### PR DESCRIPTION
## Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1640
Upgraded openMRSVersion to 2.4.2

## Solution
Add missing dependencies that have been generated due to version upgrade.
Modify test cases, test data if needed

### The following changes have been made:

#### Udpated

- openMRS v2.1.1 -> 2.4.2
- openMRSWebServicesVersion v2.17 -> 2.29.0

### Testing
The screenshots for successful compilation have been added on the ticket.
