### PR TITLE
BAH-1863 Upgrade OMRS version from 2.4.2 to 2.5.0 in Pacs Query Module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 	</distributionManagement>
 
     <properties>
-        <openmrsPlatformVersion>2.4.2</openmrsPlatformVersion>
+        <openmrsPlatformVersion>2.5.0</openmrsPlatformVersion>
 		<openmrsWebServicesVersion>2.29.0</openmrsWebServicesVersion>
     </properties>
 


### PR DESCRIPTION
### Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1863
Upgraded openMRSVersion to 2.5.0

### Solution
Add missing dependencies that have been generated due to version upgrade.

## The following changes have been made:

- udpated
openMRS v2.4.2 -> 2.5.0


### Testing
The screenshots for successful compilation have been added on the ticket.